### PR TITLE
Use asymptotic method in the ks_2samp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miautawn-auto-validate-by-history"
-version = "0.1.0"
+version = "0.1.1"
 description = "Automatic data quality validation for data pipelines"
 authors = ["miautawn <miautawn@gmail.com>"]
 packages = [

--- a/src/avh/auto_validate_by_history.py
+++ b/src/avh/auto_validate_by_history.py
@@ -106,9 +106,9 @@ class AVH:
     @property
     def default_constraint_estimators(self) -> List[constraints.ConstraintType]:
         return [
-            constraints.CLTConstraint,
             constraints.ChebyshevConstraint,
             constraints.CantelliConstraint,
+            constraints.CLTConstraint,
         ]
 
     @property

--- a/src/avh/metrics/_numeric.py
+++ b/src/avh/metrics/_numeric.py
@@ -76,7 +76,7 @@ class KsDist(NumericMetricMixin, TwoDistributionMetric):
         if self._is_empty(new_sample, old_sample):
             return np.inf
 
-        _, ks_p_val = ks_2samp(new_sample, old_sample, nan_policy="omit")
+        _, ks_p_val = ks_2samp(new_sample, old_sample, nan_policy="omit", method="asymp")
         return 1 - ks_p_val
 
 


### PR DESCRIPTION
This PR changes the scipy `ks_2samp` method parameter `method` from `auto` to `asymp`, since it's a lot faster when dealing with medium size datasets.

The `PS` creation on one column for 10k dataframes, went down from 3s -> 1s.