### PR TITLE
Feature timeseries differencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The authors provide an official repository for their version of the implementati
 # Features
 The package tries to implement all the features described in the paper, however, some are still missing at this point & will be implemented with future releases!
 ## Unsupported features
-- [ ] Stationarity testing (currently only stationary data is supported).
+- [x] Stationarity testing (currently only stationary data is supported).
 - [ ] Categorical data issues & metrics (currently only numerical data is fully supported).
 
 # Setup

--- a/poetry.lock
+++ b/poetry.lock
@@ -1697,6 +1697,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-
 type = ["mypy (>=1.8)"]
 
 [[package]]
+name = "plotly"
+version = "5.22.0"
+description = "An open-source, interactive data visualization library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "plotly-5.22.0-py3-none-any.whl", hash = "sha256:68fc1901f098daeb233cc3dd44ec9dc31fb3ca4f4e53189344199c43496ed006"},
+    {file = "plotly-5.22.0.tar.gz", hash = "sha256:859fdadbd86b5770ae2466e542b761b247d1c6b49daed765b95bb8c7063e7469"},
+]
+
+[package.dependencies]
+packaging = "*"
+tenacity = ">=6.2.0"
+
+[[package]]
 name = "pre-commit"
 version = "3.7.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -2496,6 +2511,21 @@ develop = ["colorama", "cython (>=0.29.33)", "cython (>=3.0.10,<4)", "flake8", "
 docs = ["ipykernel", "jupyter-client", "matplotlib", "nbconvert", "nbformat", "numpydoc", "pandas-datareader", "sphinx"]
 
 [[package]]
+name = "tenacity"
+version = "8.3.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-8.3.0-py3-none-any.whl", hash = "sha256:3649f6443dbc0d9b01b9d8020a9c4ec7a1ff5f6f3c6c8a036ef371f573fe9185"},
+    {file = "tenacity-8.3.0.tar.gz", hash = "sha256:953d4e6ad24357bceffbc9707bc74349aca9d245f68eb65419cf0c249a1949a2"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "terminado"
 version = "0.18.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -2777,4 +2807,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "d36941afe749b9767ea0a460ad1706f8841dad462597a9d4a0096a30bb4380a7"
+content-hash = "9b66f5c38cac27a350a1fed6b8339070d2cdeed07633a681f37168c87ae9b72c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ module = [
   "sklearn.*",
   "tqdm.*",
   "scipy.*",
-  "joblib.*"
+  "joblib.*",
+  "statsmodels.*"
 ]
 
 [tool.autoflake]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ statsmodels = "^0.14.1"
 joblib = "^1.4.0"
 
 [tool.poetry.group.dev.dependencies]
+plotly = "^5.22.0"
 jupyter-black = "^0.3.4"
 notebook = "^7.1.0"
 pre-commit = "^3.7.0"
@@ -28,7 +29,6 @@ black = "^24.4.2"
 isort = "^5.13.2"
 mypy = "^1.10.0"
 autoflake = "^2.3.1"
-
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miautawn-auto-validate-by-history"
-version = "0.1.1"
+version = "0.2.1"
 description = "Automatic data quality validation for data pipelines"
 authors = ["miautawn <miautawn@gmail.com>"]
 packages = [

--- a/src/avh/constraints/_base.py
+++ b/src/avh/constraints/_base.py
@@ -1,9 +1,10 @@
-from typing import List, Optional, Tuple, cast
+from typing import Callable, List, Optional, Tuple, cast
 
 import pandas as pd
 from sklearn.base import BaseEstimator, check_is_fitted
 
 import avh.metrics as metrics
+import avh.utility_functions as utility_functions
 
 
 class Constraint(BaseEstimator):
@@ -33,8 +34,12 @@ class Constraint(BaseEstimator):
     def __init__(
         self,
         metric: metrics.MetricType,
+        time_differencing_window: int = 0,
+        metric_preprocessing_function: Callable = utility_functions.identity,
     ):
         self.metric = metric
+        self.time_differencing_window = time_differencing_window
+        self.metric_preprocessing_function = metric_preprocessing_function
 
     def __repr__(self):
         if hasattr(self, "_is_fitted") and self._is_fitted:
@@ -51,24 +56,43 @@ class Constraint(BaseEstimator):
 
     def _get_metric_repr(self):
         metric_repr = self.metric.__name__
+        preprocessng_func_repr = self.metric_preprocessing_function.__function_repr__
+        if preprocessng_func_repr != "identity":
+            metric_repr = "{}({})".format(preprocessng_func_repr, metric_repr)
+        if self.time_differencing_window != 0:
+            metric_repr = "{}.diff({})".format(metric_repr, self.time_differencing_window)
         return metric_repr
 
     def fit(
         self,
         X: List[pd.Series],
         y=None,
-        hotload_history: Optional[List[float]] = None,
+        metric_history: Optional[List[float]] = None,
+        hotload_metric_history: Optional[List[float]] = None,
         **kwargs,
     ):
+        """
+        X - raw data
+        metric_history - calculated metric history without any pre/post-processing
+        hotload_metric_history - final metric history including pre/post-processing
+            and timeseries differencing. Constraint interval will be estimated directly on this.
+        """
 
         assert self.is_metric_compatable(self.metric), (
             f"The {self.metric.__name__} is not compatible with " f"{self.__class__.__name__}"
         )
 
-        self.metric_history_ = cast(
-            List[float],
-            hotload_history if hotload_history is not None else self.metric.calculate(X),
+        self.raw_metric_history_ = (
+            metric_history
+            if metric_history is not None
+            else cast(List[float], self.metric.calculate(X))
         )
+        self.metric_history_ = (
+            hotload_metric_history
+            if hotload_metric_history is not None
+            else self._preprocess_metric_history(self.raw_metric_history_)
+        )
+
         self._fit(self.metric_history_, raw_history=X, **kwargs)
 
         self._is_fitted = True
@@ -83,10 +107,36 @@ class Constraint(BaseEstimator):
     def predict(self, column: pd.Series, **kwargs) -> bool:
         check_is_fitted(self)
 
-        m = cast(float, self.metric.calculate(column))
+        if issubclass(self.metric, metrics.SingleDistributionMetric):
+            m = self.metric.calculate(column)
+        else:
+            m = self.metric.calculate(column, self.last_reference_sample_)
+
+        m = self._preprocess_metric(cast(float, m))
         prediction = self._predict(m, **kwargs)
 
         return prediction
 
     def _predict(self, m: float, **kwargs) -> bool:
+        print(self.raw_metric_history_)
+        print(self.metric_history_)
+        print(m)
         return self.u_lower_ <= m <= self.u_upper_
+
+    def _preprocess_metric(self, metric: float) -> float:
+        m = self.metric_preprocessing_function(metric)
+        if self.time_differencing_window > 0:
+            m = m - self.metric_preprocessing_function(
+                self.raw_metric_history_[-self.time_differencing_window]
+            )
+
+        return m
+
+    def _preprocess_metric_history(self, metric_history: List[float]) -> List[float]:
+        preprocessed_metric_history = self.metric_preprocessing_function(metric_history)
+        if self.time_differencing_window > 0:
+            time_differenced_history = (
+                pd.Series(preprocessed_metric_history).diff(self.time_differencing_window).tolist()
+            )
+            return time_differenced_history[self.time_differencing_window :]
+        return preprocessed_metric_history

--- a/src/avh/constraints/_base.py
+++ b/src/avh/constraints/_base.py
@@ -118,9 +118,6 @@ class Constraint(BaseEstimator):
         return prediction
 
     def _predict(self, m: float, **kwargs) -> bool:
-        print(self.raw_metric_history_)
-        print(self.metric_history_)
-        print(m)
         return self.u_lower_ <= m <= self.u_upper_
 
     def _preprocess_metric(self, metric: float) -> float:

--- a/src/avh/constraints/_constraints.py
+++ b/src/avh/constraints/_constraints.py
@@ -1,10 +1,9 @@
 import math
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy import integrate
-from sklearn.base import check_is_fitted
 
 import avh.metrics as metrics
 from avh.constraints._base import Constraint
@@ -16,7 +15,9 @@ class ConstantConstraint(Constraint):
         which operates on manually provided threshold values
     """
 
-    def __init__(self, metric: metrics.MetricType, u_lower: float, u_upper: float, expected_fpr):
+    def __init__(
+        self, metric: metrics.MetricType, u_lower: float, u_upper: float, expected_fpr: float
+    ):
         super().__init__(metric)
 
         # technically not following the sklearn style guide :(
@@ -57,16 +58,6 @@ class ChebyshevConstraint(Constraint):
         else:
             self.expected_fpr_ = var / beta**2
 
-    def predict(self, column: pd.Series, **kwargs) -> bool:
-        check_is_fitted(self)
-
-        if issubclass(self.metric, metrics.SingleDistributionMetric):
-            m = self.metric.calculate(column)
-        else:
-            m = self.metric.calculate(column, self.last_reference_sample_)
-
-        return self._predict(cast(float, m), **kwargs)
-
 
 class CantelliConstraint(Constraint):
     """
@@ -104,14 +95,6 @@ class CantelliConstraint(Constraint):
             self.expected_fpr_ = 0.0
         else:
             self.expected_fpr_ = var / (var + beta**2)
-
-    def predict(self, column: pd.Series, **kwargs) -> bool:
-        check_is_fitted(self)
-
-        m = self.metric.calculate(column, self.last_reference_sample_)
-        prediction = self._predict(cast(float, m), **kwargs)
-
-        return prediction
 
 
 class CLTConstraint(Constraint):

--- a/src/avh/constraints/_data_quality_program.py
+++ b/src/avh/constraints/_data_quality_program.py
@@ -13,7 +13,7 @@ class ConjuctivDQProgram:
         contributions: Optional[List[Set[str]]] = None,
     ):
         self.constraints = constraints if constraints else []
-        self.recall = recall if recall else set({})
+        self.recall = recall if recall else set()
         self.contributions = contributions if contributions else []
 
     def __repr__(self):

--- a/src/avh/utility_functions.py
+++ b/src/avh/utility_functions.py
@@ -42,6 +42,13 @@ def diff(data: Iterable, period: int) -> np.ndarray:
 
 
 def function_repr(repr):
+    """
+    Decorator function to set the '__function_repr__' field
+        for the targetted function.
+
+    Used in scikit-learn representations.
+    """
+
     def wrapper(func):
         setattr(func, "__function_repr__", repr)
         return func
@@ -58,13 +65,13 @@ def identity(x: Any) -> Any:
 
 
 @function_repr("log")
-def safe_log(x: Union[Number, Iterable]) -> np.ndarray:
+def safe_log(x: Union[Number, Iterable]) -> Union[Number, np.ndarray]:
     """
     Perform log(x), but with safeguards
         against cases where x == 0
     """
     data = np.array(x)
-    log_data = np.log(data, out=np.zeros_like(data, dtype=np.float32), where=(data != 0))
+    log_data = np.log(data, where=(data != 0))
 
     if log_data.shape:
         return log_data


### PR DESCRIPTION
This PR adds the stationarity testing option for the `AVH` algorithm, which tries to automatically fix data into stationarity by using time differencing with different lags.

The new `time_differencing` parameter is used when defining the `AVH` object:
```python
from avh.auto_validate_by_history import AVH

avh = AVH(time_differencing=0)
```

It can take the following values:
* `0` - do not apply any time differencing (default).
* `>0` - will apply time differencing using this as param lag.
* `"auto"` - will try to find the stationarity with different lag options by using `adfuller` tests.
